### PR TITLE
aidan-suggestion breaks application.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,10 @@
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/config/event-sourcing.php
+++ b/config/event-sourcing.php
@@ -7,7 +7,7 @@ return [
      * will be registered to Projectionist automatically.
      */
     'auto_discover_projectors_and_reactors' => [
-        // app()->path('Domain'),
+        app()->path('app/Domain'),
     ],
 
     /*
@@ -22,7 +22,6 @@ return [
      * Projectors can be registered in this array or a service provider.
      */
     'projectors' => [
-        \Domain\App\Projectors\SampleProjector::class,
         // App\Projectors\YourProjector::class
     ],
 
@@ -32,7 +31,6 @@ return [
      * Reactors can be registered in this array or a service provider.
      */
     'reactors' => [
-        \Domain\App\Reactors\SampleReactor::class,
         // App\Reactors\YourReactor::class
     ],
 


### PR DESCRIPTION
I have tested multiple different versions of the configurations before and eventually had to leave the `auto_discover_projectors_and_reactors` empty and manually register the `Projectors` and `Reactors` which is the only way this works for when these are located in a different domain.